### PR TITLE
Prevent crash when header input string does not contain a colon

### DIFF
--- a/ui/viewport/headers.go
+++ b/ui/viewport/headers.go
@@ -92,15 +92,23 @@ func (model headersModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		case tea.KeyEnter:
 			if model.verticalPosition == INPUT {
 				parts := strings.Split(model.headerInput.Value(), ":")
-				key, value := strings.Trim(parts[0], " "), strings.Trim(parts[1], " ")
+				var (
+					key   string
+					value string
+				)
+				if len(parts) < 2 {
+					return model, nil
+				} else {
+					key = strings.Trim(parts[0], " ")
+					value = strings.Trim(strings.Join(parts[1:], ":"), " ")
+					cmd := func() tea.Msg {
+						return lib.Pair{Key: key, Value: value}
+					}
 
-				cmd := func() tea.Msg {
-					return lib.Pair{Key: key, Value: value}
+					model.headerInput.SetValue("")
+
+					return model, cmd
 				}
-
-				model.headerInput.SetValue("")
-
-				return model, cmd
 			}
 
 		case tea.KeyUp:


### PR DESCRIPTION
# Current behavior:
1. Input string without a colon in header field
2. Hit Enter (be it intentionally or accidentally)
3. Program crashes due to index out of range panic

# New behavior
1. Input string without a colon in header field
2. Hit Enter (be it intentionally or accidentally)
3. If input string contains a colon
  a. Add header
  b. Clear input field
4. If input string does not contain a header
  a. Do not add to headers
  b. Maintain input unchanged
